### PR TITLE
Include "*.ifn" files in output

### DIFF
--- a/payload_charlie/process_payload/run.sh
+++ b/payload_charlie/process_payload/run.sh
@@ -19,6 +19,6 @@ cd $INPUT_DIR
 /opt/charlie/tCharlie.sh $(cat cli_parameters.txt) &> runlog.txt
 
 
-cp ./*.txt ../$OUTPUT_DIR
+cp ./*.txt ./*.ifn ../$OUTPUT_DIR
 
 # --- EOF ---


### PR DESCRIPTION
Charlie generates "*.ifn" result files (plaintext). 

It does not appear that this extension can be overridden at the command line.

This commit includes those files in the output directory.